### PR TITLE
fix: simple modification retrieving the DOM form element

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,5 +10,3 @@ setupZoomSlider();
 setupKeyboard();
 haddleNavbar();
 
-alert('gaaaa!');
-

--- a/src/userobjects.js
+++ b/src/userobjects.js
@@ -152,10 +152,9 @@ export function selectionChanged(graph, cell) {
 export function selectionChangedForConnections(graph, cell)
 //Se define una función llamada selectionChanged que toma un argumento graph, que se supone que es una instancia del gráfico mxGraph.
 {
-  var elemento = document.querySelector('#edit-section');
   openEditSection();
 
-  var div = document.getElementById('#edit-section');
+  var div = document.getElementById('edit-section');
   //Se obtiene una referencia al elemento HTML con el ID 'properties'. Esto se utiliza para manipular el contenido del panel de propiedades.
 
   // Clears the DIV the non-DOM way


### PR DESCRIPTION
### Changes

- Se borro el codigo `alert('gaaa')`
- Corregi la seleccion de un elemento DOM por id. El error era que al usar la funcion `document.getElementById(param)` el parametro `param` no debe contener asterisco `#`.

---

Close #38 
